### PR TITLE
Corrige branch do trigger e adiciona possibilidade de rodar a liberação da release manualmente

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -3,7 +3,8 @@ name: Build and Release from Merged PR
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [master]
+  workflow_dispatch:
 
 jobs:
   create-release:


### PR DESCRIPTION
No PR anterior, a branch em que o PR apontava foi definida como main, e não master.